### PR TITLE
Don't shadow PATH as a local variable

### DIFF
--- a/util/rmvim
+++ b/util/rmvim
@@ -26,7 +26,7 @@ do  case "$o" in
     esac
 done
 shift $(($OPTIND-1))
-FILEPATH=$1
+FILEPATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 
 # VALUES
 LHOST=${SSH_CONNECTION%% *}
@@ -43,10 +43,10 @@ if [ $VERBOSE -eq 1 ]; then
 fi
 
 if which nc > /dev/null; then
-    echo -e "open:scp://$RHOST/$(pwd)/$FILEPATH" | nc "$HOST" "$PORT"
+    echo -e "open:scp://$RHOST/$FILEPATH" | nc "$HOST" "$PORT"
 else
     exec 3<>/dev/tcp/$HOST/$PORT # Open tcp connection and assign fd 3 to it
-    echo -e "open:scp://$RHOST/$(pwd)/$FILEPATH" >&3
+    echo -e "open:scp://$RHOST/$FILEPATH" >&3
     exec 3>&- # Close fd 3
 fi
 

--- a/util/rmvim
+++ b/util/rmvim
@@ -9,7 +9,7 @@ VERSION='rmvim version 1.0.1 (2012-06-03)'
 HOST=localhost
 PORT=52699
 VERBOSE=0
-PATH=""
+FILEPATH=""
 
 USAGE="Usage: rmvim [-vVh] [-p portnumber] file"
 
@@ -26,7 +26,7 @@ do  case "$o" in
     esac
 done
 shift $(($OPTIND-1))
-PATH=$1
+FILEPATH=$1
 
 # VALUES
 LHOST=${SSH_CONNECTION%% *}
@@ -43,10 +43,10 @@ if [ $VERBOSE -eq 1 ]; then
 fi
 
 if which nc > /dev/null; then
-    echo -e "open:scp://$RHOST/$(pwd)/$PATH" | nc "$HOST" "$PORT"
+    echo -e "open:scp://$RHOST/$(pwd)/$FILEPATH" | nc "$HOST" "$PORT"
 else
     exec 3<>/dev/tcp/$HOST/$PORT # Open tcp connection and assign fd 3 to it
-    echo -e "open:scp://$RHOST/$(pwd)/$PATH" >&3
+    echo -e "open:scp://$RHOST/$(pwd)/$FILEPATH" >&3
     exec 3>&- # Close fd 3
 fi
 


### PR DESCRIPTION
When I ran rmvim, I would consistently see:
   rmvim: line 45: which: command not found

This seemed strange, because "which" existed, of course. I inspected the rmvim script, and realized it was using PATH as the variable to store the file that the user wants to edit. But this means the shell can't find the "which" command, since it tries to search the PATH.

I fixed the bug by renaming rmvim's PATH variable to FILEPATH, which has no special meaning to the shell.